### PR TITLE
Refer to 1.10.0 release

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Fusion Data Explorer</title>
-    <link href="https://unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
+    <link href="https://unpkg.com/graphiql@1.10.0/graphiql.min.css" rel="stylesheet" />
   </head>
   <div id="warningBanner" style="
   padding: 10px;
@@ -34,7 +34,7 @@
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/graphiql/graphiql.min.js"
+      src="https://unpkg.com/graphiql@1.10.0/graphiql.min.js"
     ></script>
 
     <script>


### PR DESCRIPTION
Refer to the 1.10.0 release instead of the new 1.11.x, which has an additional introspection button with no logic to disable or hide it. 

This introspection button change is still not stable. It is not advisable for us to use it (as it is)